### PR TITLE
fix: trim all listed phpcs standards

### DIFF
--- a/src/de/foopara/phpcsmd/ui/phpcs/PhpcsPanel.java
+++ b/src/de/foopara/phpcsmd/ui/phpcs/PhpcsPanel.java
@@ -312,7 +312,7 @@ public class PhpcsPanel extends GenericOptionsPanel
         String installed[] = Phpcs.getStandards(optScript.getText());
         if (installed != null && installed.length > 0) {
             for (String standard : installed) {
-                ((DefaultComboBoxModel)this.jComboBox1.getModel()).addElement(standard);
+                ((DefaultComboBoxModel)this.jComboBox1.getModel()).addElement(standard.trim());
             }
         }
     }//GEN-LAST:event_jButton2ActionPerformed


### PR DESCRIPTION
the last listed standard was imported with a trailing white space when selected

Signed-off-by:Eric Villard dev@eviweb.fr
